### PR TITLE
Fix: Resolve Docker build error and ensure proper service startup.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,5 @@ RUN mkdir -p /data/{docs,database}
 
 # Pull the LLM model
 # This command is executed by the ollama CLI after its installation.
-RUN echo "Pulling Gemma model..." &&     ollama pull gemma3:1b &&     echo "Gemma model pull finished."
 
 CMD ["bash", "scripts/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8' # Using a slightly newer version for consistency, 3.5 features are compatible.
+# version: '3.8' # Using a slightly newer version for consistency, 3.5 features are compatible.
 
 services:
   etcd:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,6 +7,11 @@ ollama serve &
 # Optional: Give Ollama a few seconds to start
 sleep 5 
 
+# Pull the Gemma model
+echo "Pulling Gemma model..."
+ollama pull gemma3:1b
+echo "Gemma model pull finished."
+
 echo "Ollama server started. Proceeding with initialization..."
 
 # Initialize databases and sync documents


### PR DESCRIPTION
- I modified the Dockerfile to remove `ollama pull` during build. The Ollama server is not active during the image build phase, causing this command to fail.
- I updated `scripts/start.sh` to execute `ollama pull gemma3:1b` after starting `ollama serve`. This ensures the model is pulled when the server is running.
- I commented out the obsolete `version` tag in `docker-compose.yml` to remove warnings during `docker compose up`.

These changes address the reported Docker build failure and ensure that both Ollama and Milvus services start as expected.